### PR TITLE
Store window state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,10 +12,82 @@ This project is created for educational purposes only.
 copyright @ Tanmoy Ganguly
 */
 
-import { app, BrowserWindow, shell } from 'electron';
+import fs from 'fs';
+import { app, BrowserWindow, shell, screen } from 'electron';
 import path from 'path';
 import { config } from './config/index.js';
 import { fileURLToPath } from 'url';  // <-- Import `fileURLToPath` from 'url'
+
+// Define path for storing window state
+const stateFilePath = path.join(app.getPath('userData'), 'window-state.json');
+
+
+/**
+ * Loads saved window state and ensures it is within available screen bounds.
+ */
+function loadWindowState() {
+    try {
+
+        const state = JSON.parse(fs.readFileSync(stateFilePath, 'utf-8'));
+
+        // Get all displays and check if the saved display still exists
+        const displays = screen.getAllDisplays();
+
+        const display = displays.find(d => 
+            state.displayBounds &&
+            d.bounds.x === state.displayBounds.x &&
+            d.bounds.y === state.displayBounds.y
+        );
+
+        if (!display) {
+            console.log("Previous display not found, using primary display.");
+            return getCenteredWindowState(state.width, state.height);
+        }
+
+        // Ensure the window is within the bounds of the selected display
+        if (
+            state.x < display.bounds.x || state.y < display.bounds.y ||
+            state.x + state.width > display.bounds.x + display.bounds.width ||
+            state.y + state.height > display.bounds.y + display.bounds.height
+        ) {
+            console.log("Window was out of bounds, repositioning...");
+            return getCenteredWindowState(state.width, state.height, display.bounds);
+        }
+
+        return state;
+    } catch (error) {
+        return getCenteredWindowState(800, 600); // Default size
+    }
+}
+
+/**
+ * Saves window state including display information before closing.
+ */
+function saveWindowState(win) {
+    if (!win.isMinimized()) {
+        console.log("Save window state");
+        const bounds = win.getBounds();
+        const display = screen.getDisplayMatching(bounds); // Get the display where the window is currently located
+        fs.writeFileSync(stateFilePath, JSON.stringify({
+            ...bounds,
+            displayBounds: display.bounds
+        }));
+    }
+}
+
+/**
+ * Calculates a centered window state based on the given screen bounds.
+ */
+function getCenteredWindowState(width, height, bounds = screen.getPrimaryDisplay().bounds) {
+    return {
+        width,
+        height,
+        x: Math.max(bounds.x, Math.floor(bounds.x + (bounds.width - width) / 2)),
+        y: Math.max(bounds.y, Math.floor(bounds.y + (bounds.height - height) / 2)),
+        displayBounds: bounds
+    };
+}
+
 
 // Dynamically import the context menu module
 import('electron-context-menu').then((contextMenu) => {
@@ -44,7 +116,12 @@ function onNewWindow(details) {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));  // <-- Updated: Calculate `__dirname` directly
 
 const createWindow = () => {
+    const windowState = loadWindowState();
     window = new BrowserWindow({
+        width: windowState.width,
+        height: windowState.height,
+        x: windowState.x,
+        y: windowState.y,
         icon: path.join(__dirname, 'assets/icon.png'),
         autoHideMenuBar: true
     });
@@ -52,9 +129,7 @@ const createWindow = () => {
 
     window.webContents.setWindowOpenHandler(onNewWindow);
 
-    window.once('ready-to-show', () => {
-        window.maximize();
-    });
+    window.on('close', () => saveWindowState(window));
 };
 
 const appLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
I implemented some small changes so that the state of the window is stored, which is the size, position and display in which it is shown.

By default it loads with a size of 800x600 and centered.

It will store the settings in this path: 

Linux:
`/home/<Username>/.config/whatsapp-desktop-client/window-state.json`

Windows:
`C:\Users\<Username>\AppData\Roaming\whatsapp-desktop-client\window-state.json`

macOS:
`/Users/<Username>/Library/Application Support/whatsapp-desktop-client/window-state.json`

